### PR TITLE
Step07 integration

### DIFF
--- a/src/main/kotlin/kr/hhplus/be/server/config/jpa/JpaConfig.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/config/jpa/JpaConfig.kt
@@ -9,7 +9,6 @@ import org.springframework.transaction.PlatformTransactionManager
 
 @Configuration
 @EnableJpaAuditing
-@EnableJpaRepositories
 class JpaConfig {
     @Bean
     fun transactionManager(): PlatformTransactionManager {

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/CouponConverter.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/CouponConverter.kt
@@ -1,0 +1,26 @@
+package kr.hhplus.be.server.infrastructure.coupon
+
+import kr.hhplus.be.server.domain.coupon.Coupon
+
+object CouponConverter {
+
+    fun toDomain(couponEntity: CouponEntity): Coupon {
+        return Coupon(
+            couponEntity.id,
+            couponEntity.name,
+            couponEntity.discountAmount,
+            couponEntity.quantity,
+            couponEntity.expiredAt
+        )
+    }
+
+    fun toEntity(coupon: Coupon): CouponEntity {
+        return CouponEntity(
+            coupon.couponId,
+            coupon.name,
+            coupon.discountAmount,
+            coupon.quantity,
+            coupon.expiredAt
+        )
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/CouponEntity.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/CouponEntity.kt
@@ -1,0 +1,17 @@
+package kr.hhplus.be.server.infrastructure.coupon
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "coupon")
+class CouponEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id : Long = 0,
+    val name: String,
+    val discountAmount: Long,
+    var quantity : Long,
+    val expiredAt : LocalDateTime,
+) {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/CouponRepositoryImpl.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/CouponRepositoryImpl.kt
@@ -5,17 +5,27 @@ import kr.hhplus.be.server.domain.coupon.CouponRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-class CouponRepositoryImpl: CouponRepository {
+class CouponRepositoryImpl(
+    private val jpaCouponRepository: JpaCouponRepository
+): CouponRepository {
 
     override fun findById(couponId: Long): Coupon {
-        TODO("Not yet implemented")
+        return jpaCouponRepository.findById(couponId).orElseThrow().let{
+            CouponConverter.toDomain(it)
+        }
     }
 
     override fun save(coupon: Coupon): Coupon {
-        TODO("Not yet implemented")
+        val couponEntity= jpaCouponRepository.save(
+            CouponConverter.toEntity(coupon)
+        )
+        return  CouponConverter.toDomain(couponEntity)
     }
 
     override fun findByIds(couponIds: List<Long>): List<Coupon> {
-        TODO("Not yet implemented")
+        val couponEntityList = jpaCouponRepository.findAllById(couponIds)
+        return couponEntityList.map{
+            CouponConverter.toDomain(it)
+        }
     }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/JpaCouponRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/JpaCouponRepository.kt
@@ -1,0 +1,6 @@
+package kr.hhplus.be.server.infrastructure.coupon
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaCouponRepository: JpaRepository<CouponEntity, Long> {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/JpaUserCouponRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/JpaUserCouponRepository.kt
@@ -1,0 +1,8 @@
+package kr.hhplus.be.server.infrastructure.coupon
+
+import kr.hhplus.be.server.domain.coupon.UserCoupon
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaUserCouponRepository : JpaRepository<UserCouponEntity, Long> {
+    fun findByUserId(userId: Long): List<UserCouponEntity>
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/UserCouponConverter.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/UserCouponConverter.kt
@@ -1,0 +1,28 @@
+package kr.hhplus.be.server.infrastructure.coupon
+
+import kr.hhplus.be.server.domain.coupon.UserCoupon
+
+object UserCouponConverter {
+
+    fun toDomain(userCouponEntity: UserCouponEntity): UserCoupon{
+        return UserCoupon(
+            userCouponId = userCouponEntity.id,
+            userId = userCouponEntity.userId,
+            couponId = userCouponEntity.couponId,
+            couponStatus = userCouponEntity.status,
+            issuedAt = userCouponEntity.createdAt,
+            usedAt = userCouponEntity.usedAt
+        )
+    }
+
+    fun toEntity(userCoupon: UserCoupon): UserCouponEntity{
+        return UserCouponEntity(
+            id = userCoupon.userCouponId,
+            userId = userCoupon.userId,
+            couponId = userCoupon.couponId,
+            status = userCoupon.couponStatus,
+            usedAt = userCoupon.usedAt,
+            createdAt = userCoupon.issuedAt
+        )
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/UserCouponEntity.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/UserCouponEntity.kt
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.infrastructure.coupon
+
+import jakarta.persistence.*
+import kr.hhplus.be.server.domain.coupon.CouponStatus
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "user_coupon")
+class UserCouponEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    val userId: Long,
+    val couponId: Long,
+    @Enumerated(EnumType.STRING)
+    val status: CouponStatus,
+    val usedAt: LocalDateTime? = null,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime? = null,
+) {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/UserCouponRepositoryImpl.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/UserCouponRepositoryImpl.kt
@@ -3,18 +3,31 @@ package kr.hhplus.be.server.infrastructure.coupon
 import kr.hhplus.be.server.domain.coupon.UserCoupon
 import kr.hhplus.be.server.domain.coupon.UserCouponRepository
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 
 @Repository
-class UserCouponRepositoryImpl: UserCouponRepository {
+class UserCouponRepositoryImpl(
+    private val jpaUserCouponRepository: JpaUserCouponRepository
+): UserCouponRepository {
+
     override fun findByUserId(userId: Long): List<UserCoupon> {
-        TODO("Not yet implemented")
+        return jpaUserCouponRepository.findByUserId(userId).map{
+            UserCouponConverter.toDomain(it)
+        }
     }
 
     override fun findById(userCouponId: Long): UserCoupon {
-        TODO("Not yet implemented")
+        return jpaUserCouponRepository.findById(userCouponId).orElseThrow()
+            .let {
+                UserCouponConverter.toDomain(it)
+            }
     }
 
+    @Transactional
     override fun save(userCoupon: UserCoupon): UserCoupon {
-        TODO("Not yet implemented")
+        val userCouponEntity = jpaUserCouponRepository.save(
+            UserCouponConverter.toEntity(userCoupon)
+        )
+        return  UserCouponConverter.toDomain(userCouponEntity)
     }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/order/JpaOrderItemRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/order/JpaOrderItemRepository.kt
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.infrastructure.order
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaOrderItemRepository: JpaRepository<OrderItemEntity, Long> {
+    fun findByOrderId(orderId: Long): List<OrderItemEntity>
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/order/JpaOrderRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/order/JpaOrderRepository.kt
@@ -1,0 +1,6 @@
+package kr.hhplus.be.server.infrastructure.order
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaOrderRepository: JpaRepository<OrderEntity, Long> {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/order/OrderConverter.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/order/OrderConverter.kt
@@ -1,0 +1,27 @@
+package kr.hhplus.be.server.infrastructure.order
+
+import kr.hhplus.be.server.domain.order.Order
+
+object OrderConverter {
+
+    fun toDomain(orderEntity: OrderEntity): Order{
+        return Order(
+            orderEntity.id,
+            orderEntity.userId,
+            orderEntity.userCouponId,
+            orderEntity.status,
+            orderEntity.totalPrice
+        )
+    }
+
+
+    fun toEntity(order: Order): OrderEntity {
+        return OrderEntity(
+            order.id,
+            order.userId,
+            order.userCouponId,
+            order.status,
+            order.totalPrice
+        )
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/order/OrderEntity.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/order/OrderEntity.kt
@@ -1,0 +1,18 @@
+package kr.hhplus.be.server.infrastructure.order
+
+import jakarta.persistence.*
+import kr.hhplus.be.server.domain.order.OrderStatus
+
+
+@Entity
+@Table(name = "orders")
+class OrderEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+    val userId: Long,
+    val userCouponId: Long?,
+    val status : OrderStatus,
+    val totalPrice: Long
+) {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/order/OrderItemConverter.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/order/OrderItemConverter.kt
@@ -1,0 +1,34 @@
+package kr.hhplus.be.server.infrastructure.order
+
+import kr.hhplus.be.server.domain.order.OrderItem
+
+object OrderItemConverter {
+
+    fun toDomain(orderItemEntity: OrderItemEntity): OrderItem {
+        return OrderItem(
+            orderItemEntity.orderId,
+            orderItemEntity.productId,
+            orderItemEntity.price,
+            orderItemEntity.quantity,
+            orderItemEntity.createdAt
+        )
+    }
+
+    fun toEntity(orderItem: OrderItem): OrderItemEntity {
+        return OrderItemEntity(
+            orderId = orderItem.orderId,
+            productId = orderItem.productId,
+            price = orderItem.price,
+            quantity = orderItem.quantity,
+            createdAt = orderItem.createdAt
+        )
+    }
+
+    fun toEntityList(domains: List<OrderItem>): List<OrderItemEntity> {
+        return domains.map { toEntity(it) }
+    }
+
+    fun toDomainList(entities: List<OrderItemEntity>): List<OrderItem> {
+        return entities.map { toDomain(it) }
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/order/OrderItemEntity.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/order/OrderItemEntity.kt
@@ -1,0 +1,18 @@
+package kr.hhplus.be.server.infrastructure.order
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "order_item")
+class OrderItemEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    val orderId: Long,
+    val productId: Long,
+    val price: Long,
+    val quantity: Int,
+    val createdAt: LocalDateTime,
+) {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/order/OrderItemRepositoryImpl.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/order/OrderItemRepositoryImpl.kt
@@ -3,14 +3,23 @@ package kr.hhplus.be.server.infrastructure.order
 import kr.hhplus.be.server.domain.order.OrderItem
 import kr.hhplus.be.server.domain.order.OrderItemRepository
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 
 @Repository
-class OrderItemRepositoryImpl: OrderItemRepository {
+class OrderItemRepositoryImpl(
+    private val jpaOrderItemRepository: JpaOrderItemRepository
+): OrderItemRepository {
+    @Transactional
     override fun saveAll(orderItem: List<OrderItem>): List<OrderItem> {
-        TODO("Not yet implemented")
+        val orderItemEntities = jpaOrderItemRepository.saveAll(
+            OrderItemConverter.toEntityList(orderItem)
+        )
+
+        return OrderItemConverter.toDomainList(orderItemEntities)
     }
 
     override fun findByOrderId(orderId: Long): List<OrderItem> {
-        TODO("Not yet implemented")
+        val orderItemEntity= jpaOrderItemRepository.findByOrderId(orderId)
+        return OrderItemConverter.toDomainList(orderItemEntity)
     }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/order/OrderRepositoryImpl.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/order/OrderRepositoryImpl.kt
@@ -3,14 +3,24 @@ package kr.hhplus.be.server.infrastructure.order
 import kr.hhplus.be.server.domain.order.Order
 import kr.hhplus.be.server.domain.order.OrderRepository
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 
 @Repository
-class OrderRepositoryImpl: OrderRepository {
+class OrderRepositoryImpl(
+    private val jpaOrderRepository: JpaOrderRepository
+) : OrderRepository {
     override fun findById(orderId: Long): Order {
-        TODO("Not yet implemented")
+        return jpaOrderRepository.findById(orderId).orElseThrow()
+            .let {
+                OrderConverter.toDomain(it)
+            }
     }
 
+    @Transactional
     override fun save(order: Order): Order {
-        TODO("Not yet implemented")
+        val orderEntity = jpaOrderRepository.save(
+            OrderConverter.toEntity(order)
+        )
+        return OrderConverter.toDomain(orderEntity)
     }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/payment/JpaPaymentRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/payment/JpaPaymentRepository.kt
@@ -1,0 +1,6 @@
+package kr.hhplus.be.server.infrastructure.payment
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaPaymentRepository: JpaRepository<PaymentEntity, Long> {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/payment/PaymentConverter.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/payment/PaymentConverter.kt
@@ -1,0 +1,27 @@
+package kr.hhplus.be.server.infrastructure.payment
+
+import kr.hhplus.be.server.domain.payment.Payment
+
+object PaymentConverter {
+
+    fun toDomain(paymentEntity: PaymentEntity): Payment {
+        return Payment(
+            id = paymentEntity.id,
+            orderId = paymentEntity.orderId,
+            status = paymentEntity.status,
+            paymentAmount = paymentEntity.paymentAmount,
+            paidAt = paymentEntity.paidAt,
+        )
+    }
+
+
+    fun toEntity(payment: Payment): PaymentEntity {
+        return PaymentEntity(
+            id = payment.id,
+            orderId = payment.orderId,
+            status = payment.status,
+            paymentAmount = payment.paymentAmount,
+            paidAt = payment.paidAt,
+        )
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/payment/PaymentEntity.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/payment/PaymentEntity.kt
@@ -1,0 +1,19 @@
+package kr.hhplus.be.server.infrastructure.payment
+
+import jakarta.persistence.*
+import kr.hhplus.be.server.domain.payment.PaymentStatus
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "payment")
+class PaymentEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    val orderId: Long,
+    @Enumerated(EnumType.STRING)
+    val status: PaymentStatus,
+    val paymentAmount: Long,
+    val paidAt: LocalDateTime? = null,
+) {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/payment/PaymentRepositoryImpl.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/payment/PaymentRepositoryImpl.kt
@@ -3,10 +3,17 @@ package kr.hhplus.be.server.infrastructure.payment
 import kr.hhplus.be.server.domain.payment.Payment
 import kr.hhplus.be.server.domain.payment.PaymentRepository
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 
 @Repository
-class PaymentRepositoryImpl: PaymentRepository {
+class PaymentRepositoryImpl(
+    private val jpaPaymentRepository: JpaPaymentRepository,
+): PaymentRepository {
+    @Transactional
     override fun save(payment: Payment): Payment {
-        TODO("Not yet implemented")
+        val paymentEntity = jpaPaymentRepository.save(
+            PaymentConverter.toEntity(payment)
+        )
+        return PaymentConverter.toDomain(paymentEntity)
     }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/point/JpaUserPointRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/point/JpaUserPointRepository.kt
@@ -1,0 +1,6 @@
+package kr.hhplus.be.server.infrastructure.point
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaUserPointRepository: JpaRepository<UserPointEntity,Long> {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/point/UserPointConverter.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/point/UserPointConverter.kt
@@ -1,0 +1,23 @@
+package kr.hhplus.be.server.infrastructure.point
+
+import kr.hhplus.be.server.domain.point.UserPoint
+
+
+object UserPointConverter {
+
+    fun toDomain(userPointEntity: UserPointEntity): UserPoint {
+        return UserPoint(
+            id = userPointEntity.id,
+            userId = userPointEntity.userId,
+            point = userPointEntity.point,
+        )
+    }
+
+    fun toEntity(userPoint: UserPoint): UserPointEntity {
+        return UserPointEntity(
+            id = userPoint.id,
+            userId = userPoint.userId,
+            point = userPoint.point,
+        )
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/point/UserPointEntity.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/point/UserPointEntity.kt
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.infrastructure.point
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "user_point")
+class UserPointEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    val userId: Long,
+    val point: Long
+) {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/point/UserPointRepositoryImpl.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/point/UserPointRepositoryImpl.kt
@@ -3,16 +3,25 @@ package kr.hhplus.be.server.infrastructure.point
 import kr.hhplus.be.server.domain.point.UserPoint
 import kr.hhplus.be.server.domain.point.UserPointRepository
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 
 @Repository
-class UserPointRepositoryImpl(): UserPointRepository {
+class UserPointRepositoryImpl(
+    private val jpaUserPointRepository: JpaUserPointRepository
+): UserPointRepository {
 
     override fun findByUserId(userId: Long): UserPoint {
-        TODO("Not yet implemented")
+        return jpaUserPointRepository.findById(userId).orElseThrow().let {
+            UserPointConverter.toDomain(it)
+        }
     }
 
-    override fun save(point: UserPoint): UserPoint {
-        TODO("Not yet implemented")
+    @Transactional
+    override fun save(userPoint: UserPoint): UserPoint {
+        val userPointEntity = jpaUserPointRepository.save(
+            UserPointConverter.toEntity(userPoint)
+        )
+        return UserPointConverter.toDomain(userPointEntity)
     }
 
 }

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/product/JpaProductRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/product/JpaProductRepository.kt
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.infrastructure.product
+
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaProductRepository: JpaRepository<ProductEntity, Long> {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/product/ProductConverter.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/product/ProductConverter.kt
@@ -1,0 +1,43 @@
+package kr.hhplus.be.server.infrastructure.product
+
+import kr.hhplus.be.server.domain.product.Product
+
+object ProductConverter {
+
+    fun toProductEntity(product: Product): ProductEntity {
+        return ProductEntity(
+            product.id,
+            name = product.name,
+            price = product.price,
+            quantity = product.quantity,
+        )
+    }
+
+
+    fun toDomain(productEntity: ProductEntity): Product {
+        return Product(
+            id = productEntity.id,
+            name = productEntity.name,
+            price = productEntity.price,
+            quantity = productEntity.quantity
+        )
+    }
+
+    fun toEntityList(products: List<Product>): List<ProductEntity> {
+        return products.map {
+            ProductEntity(
+                id = it.id,
+                name = it.name,
+                price = it.price,
+                quantity = it.quantity
+            )
+        }
+    }
+
+    fun toDomainList(products: List<ProductEntity>): List<Product> {
+        return products.mapNotNull { product ->
+                toDomain(product)
+            }
+    }
+
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/product/ProductEntity.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/product/ProductEntity.kt
@@ -1,0 +1,17 @@
+package kr.hhplus.be.server.infrastructure.product
+
+import jakarta.persistence.*
+import kr.hhplus.be.server.domain.product.Product
+
+@Entity
+@Table(name = "products")
+class ProductEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    var name: String,
+    var price: Long,
+    val quantity: Int,
+) {
+    constructor(product: Product) : this(name = "", price = 0, quantity = 0)
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/product/ProductRepositoryImpl.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/product/ProductRepositoryImpl.kt
@@ -2,32 +2,34 @@ package kr.hhplus.be.server.infrastructure.product
 
 import kr.hhplus.be.server.domain.product.Product
 import kr.hhplus.be.server.domain.product.ProductRepository
-import kr.hhplus.be.server.domain.stats.ProductStat
-import kr.hhplus.be.server.domain.stats.ProductStatsRepository
 import org.springframework.stereotype.Repository
-import java.time.LocalDateTime
+import org.springframework.transaction.annotation.Transactional
 
 @Repository
-class ProductRepositoryImpl(): ProductRepository,ProductStatsRepository {
+class ProductRepositoryImpl(
+    private val jpaProductRepository: JpaProductRepository,
+) : ProductRepository {
 
-    override fun findAll() : List<Product> {
-        TODO("Not yet implemented")
+    //전체 product 전체 조회
+    override fun findAll(): List<Product> {
+        val products = jpaProductRepository.findAll()
+        return ProductConverter.toDomainList(products)
     }
 
     override fun findByIds(ids: List<Long>): List<Product> {
-        TODO("Not yet implemented")
+        val products = jpaProductRepository.findAllById(ids)
+        return ProductConverter.toDomainList(products)
     }
 
     override fun findById(id: Long): Product {
-        TODO("Not yet implemented")
+        val product = jpaProductRepository.findById(id).orElseThrow()
+        return ProductConverter.toDomain(product)
     }
 
+    @Transactional
     override fun save(product: Product): Product {
-        TODO("Not yet implemented")
+        val productEntity = ProductConverter.toProductEntity(product)
+        val products = jpaProductRepository.save(productEntity)
+        return ProductConverter.toDomain(products)
     }
-
-    override fun findAllOrderBySalesDesc(): List<ProductStat> {
-        TODO("Not yet implemented")
-    }
-
 }

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/stat/JpaStatQueryRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/stat/JpaStatQueryRepository.kt
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.infrastructure.stat
+
+import kr.hhplus.be.server.infrastructure.order.OrderItemEntity
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
+
+
+interface JpaStatQueryRepository: JpaRepository<OrderItemEntity, Long> {
+    @Query("""
+        SELECT new kr.hhplus.be.server.infrastructure.stat.ProductStatDto(
+            orderItem.productId, SUM(orderItem.quantity)
+        )
+        FROM OrderItemEntity orderItem
+        WHERE orderItem.createdAt >= :threeDaysAgo
+        GROUP BY orderItem.productId
+        ORDER BY SUM(orderItem.quantity) DESC
+    """)
+    fun findProductSales(@Param("threeDaysAgo",) threeDaysAgo: LocalDateTime,pageable: Pageable): List<ProductStatDto>
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/stat/ProductStatDto.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/stat/ProductStatDto.kt
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.infrastructure.stat
+
+data class ProductStatDto(
+    val productId: Long,
+    val totalSales: Long,
+) {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/stat/StatConverter.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/stat/StatConverter.kt
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.infrastructure.stat
+
+import kr.hhplus.be.server.domain.stat.Stat
+
+object StatConverter {
+
+    fun toDomainList(productStatDtos: List<ProductStatDto>): List<Stat> {
+        return productStatDtos.mapIndexed { index, dto ->
+            Stat(
+                ranking = index + 1,
+                productId = dto.productId,
+                salesCount = dto.totalSales
+            )
+        }
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/stat/StatRepositoryImpl.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/stat/StatRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package kr.hhplus.be.server.infrastructure.stat
+
+import kr.hhplus.be.server.domain.stat.Stat
+import kr.hhplus.be.server.domain.stat.StatRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
+@Repository
+class StatRepositoryImpl(
+    private val jpaStatQueryRepository: JpaStatQueryRepository
+): StatRepository {
+    override fun findAllOrderBySalesDesc(): List<Stat> {
+        val threeDaysAgo = LocalDateTime.now().minusDays(3)
+        val size = PageRequest.of(0, 5)
+        val statDto = jpaStatQueryRepository.findProductSales(threeDaysAgo,size);
+        return StatConverter.toDomainList(statDto)
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,7 @@ springdoc:
     operations-sorter: method
 
 ---
-spring.config.activate.on-profile: local, test
+spring.config.activate.on-profile: local
 
 spring:
   datasource:

--- a/src/test/java/kr/hhplus/be/server/coupon/CouponServiceIntegrationTest.kt
+++ b/src/test/java/kr/hhplus/be/server/coupon/CouponServiceIntegrationTest.kt
@@ -1,0 +1,79 @@
+package kr.hhplus.be.server.coupon
+
+import kr.hhplus.be.server.application.coupon.CouponCommand
+import kr.hhplus.be.server.application.coupon.CouponService
+import kr.hhplus.be.server.domain.coupon.CouponRepository
+import kr.hhplus.be.server.domain.coupon.CouponStatus
+import kr.hhplus.be.server.domain.coupon.UserCouponRepository
+import kr.hhplus.be.server.support.IntegrationTestBase
+import kr.hhplus.be.server.support.TestFixtures
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDateTime
+
+
+class CouponServiceIntegrationTest @Autowired constructor(
+    private val couponService: CouponService,
+    private val userCouponRepository: UserCouponRepository,
+    private val couponRepository: CouponRepository
+) : IntegrationTestBase() {
+
+
+    @Test
+    fun `쿠폰을 발급할 수 있다`() {
+        //given
+        val expiredAt = LocalDateTime.now().plusDays(5)
+        couponRepository.save(
+            TestFixtures.coupon(
+                "테스트 쿠폰",
+                10000,
+                300,
+                expiredAt = expiredAt,
+            )
+        )
+        val command = CouponCommand(userId = 1L, couponId = 1L)
+
+        //when
+        val result = couponService.issue(command)
+
+        //then
+        assertAll(
+            {
+                assertThat(result.status).isEqualTo(CouponStatus.AVAILABLE.toString())
+                assertThat(result.discountAmount).isEqualTo(10000)
+                assertThat(result.expiredAt).isEqualTo(expiredAt)
+            }
+        )
+
+        val userCoupon = userCouponRepository.findByUserId(1)
+        assertThat(userCoupon).isNotEmpty
+    }
+
+
+    @Test
+    fun `유저의 쿠폰 목록을 조회할 수 있다`() {
+        //given
+        couponRepository.save(
+            TestFixtures.coupon(
+                "테스트 쿠폰",
+                10000,
+                300
+            )
+        )
+        val userId = 1L
+        val command = CouponCommand(userId = 1L, couponId = 1L)
+        couponService.issue(command)
+
+        //when
+        val result = couponService.getCoupons(userId)
+
+        //then
+        assertAll({
+            assertThat(result).hasSize(1)
+            assertThat(result[0].name).isEqualTo("테스트 쿠폰")
+        })
+    }
+
+}

--- a/src/test/java/kr/hhplus/be/server/order/OrderServiceIntegrationTest.kt
+++ b/src/test/java/kr/hhplus/be/server/order/OrderServiceIntegrationTest.kt
@@ -1,0 +1,153 @@
+package kr.hhplus.be.server.order
+
+import kr.hhplus.be.server.application.order.OrderCommand
+import kr.hhplus.be.server.application.order.OrderItemCommand
+import kr.hhplus.be.server.application.order.OrderService
+import kr.hhplus.be.server.domain.coupon.CouponStatus
+import kr.hhplus.be.server.domain.coupon.UserCoupon
+import kr.hhplus.be.server.domain.coupon.UserCouponRepository
+import kr.hhplus.be.server.domain.order.OrderItemRepository
+import kr.hhplus.be.server.domain.order.OrderRepository
+import kr.hhplus.be.server.domain.product.Product
+import kr.hhplus.be.server.domain.product.ProductRepository
+import kr.hhplus.be.server.support.IntegrationTestBase
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDateTime
+
+class OrderServiceIntegrationTest @Autowired constructor(
+    private val orderService: OrderService,
+    private val productRepository: ProductRepository,
+    private val userCouponRepository: UserCouponRepository,
+    private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository,
+) : IntegrationTestBase() {
+
+
+    @Test
+    fun `존재하지 않는 상품으로 주문 시 IllegalStateException 예외가 발생한다`() {
+        // given
+        val nonExistentProductId = 999L // 존재하지 않는 ID
+
+        val orderCommand = OrderCommand(
+            userId = 1L,
+            items = listOf(
+                OrderItemCommand(productId = nonExistentProductId, quantity = 1)
+            ),
+            userCouponId = null
+        )
+
+        // when & then
+        assertThatThrownBy {
+            orderService.create(orderCommand)
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("해당 상품을 찾을 수 없습니다")
+    }
+
+    @Test
+    fun `재고가 부족하면 주문에 실패시 IllegalStateException이 발생한다`() {
+        // given
+        val product = productRepository.save(
+            Product(
+                id = 1L,
+                name = "품절 상품",
+                price = 500L,
+                quantity = 1
+            )
+        )
+
+        val orderCommand = OrderCommand(
+            userId = 1L,
+            items = listOf(OrderItemCommand(productId = product.id, quantity = 10)),
+            userCouponId = null
+        )
+
+        // when & then
+        assertThatThrownBy {
+            orderService.create(orderCommand)
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("재고가 부족합니다.")
+    }
+
+
+    @Test
+    fun `쿠폰이 사용 불가 상태면 주문에 실패시 IllegalStateException이 발생한다`() {
+        // given
+        val product = productRepository.save(
+            Product(
+                id = 1L,
+                name = "상품",
+                price = 500L,
+                quantity = 1
+            )
+        )
+        val usedCoupon = userCouponRepository.save(
+            UserCoupon(
+                userCouponId = 0,
+                userId = 1,
+                couponId = 10,
+                couponStatus = CouponStatus.USED,
+                issuedAt = LocalDateTime.now().minusDays(1),
+                usedAt = LocalDateTime.now()
+            )
+        )
+
+        val orderCommand = OrderCommand(
+            userId = 1L,
+            items = listOf(OrderItemCommand(productId = product.id, quantity = 1)),
+            userCouponId = usedCoupon.userCouponId
+        )
+
+        // when & then
+        assertThatThrownBy {
+            orderService.create(orderCommand)
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("쿠폰이 이미 사용되었거나 만료되었습니다.")
+    }
+
+
+    @Test
+    fun `정상 주문이 생성된다`() {
+        // given
+        val product = productRepository.save(
+            Product(
+                id = 1L,
+                name = "나이키 신발",
+                price = 1000L,
+                quantity = 10
+            )
+        )
+        val userCoupon = userCouponRepository.save(
+            UserCoupon(
+                userCouponId = 0,
+                userId = 1,
+                couponId = 10,
+                couponStatus = CouponStatus.AVAILABLE,
+                issuedAt = LocalDateTime.now().minusDays(1),
+                usedAt = null
+            )
+        )
+
+        val orderCommand = OrderCommand(
+            userId = 1L,
+            items = listOf(OrderItemCommand(productId = product.id, quantity = 1)),
+            userCouponId = userCoupon.userCouponId
+        )
+
+        // when
+        val result = orderService.create(orderCommand)
+
+        // then
+        val savedOrder = orderRepository.findById(result.id)
+        val orderItems = orderItemRepository.findByOrderId(result.id)
+
+        assertAll({
+            assertThat(savedOrder).isNotNull
+            assertThat(orderItems).hasSize(1)
+        })
+    }
+
+}

--- a/src/test/java/kr/hhplus/be/server/payment/PaymentServiceIntegrationTest.kt
+++ b/src/test/java/kr/hhplus/be/server/payment/PaymentServiceIntegrationTest.kt
@@ -1,0 +1,368 @@
+package kr.hhplus.be.server.payment
+
+import kr.hhplus.be.server.application.payment.PaymentCommand
+import kr.hhplus.be.server.application.payment.PaymentService
+import kr.hhplus.be.server.domain.coupon.*
+import kr.hhplus.be.server.domain.order.*
+import kr.hhplus.be.server.domain.point.UserPoint
+import kr.hhplus.be.server.domain.point.UserPointRepository
+import kr.hhplus.be.server.domain.product.Product
+import kr.hhplus.be.server.domain.product.ProductRepository
+import kr.hhplus.be.server.support.IntegrationTestBase
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDateTime
+
+class PaymentServiceIntegrationTest @Autowired constructor(
+    private val paymentService: PaymentService,
+    private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository,
+    private val userPointRepository: UserPointRepository,
+    private val productRepository: ProductRepository,
+    private val userCouponRepository: UserCouponRepository,
+    private val couponRepository: CouponRepository
+) : IntegrationTestBase() {
+
+
+    @Test
+    fun `존재하지 않는 주문 ID로 결제 시 예외가 발생한다`() {
+        // given
+        val command = PaymentCommand(orderId = 999L) // 존재하지 않음
+
+        // when&then
+        assertThatThrownBy {
+            paymentService.create(command)
+        }.isInstanceOf(NoSuchElementException::class.java)
+    }
+
+    @Test
+    fun `존재하지 않는 상품 ID로 결제 시 예외가 발생한다`() {
+        //given
+        val order = orderRepository.save(
+            Order(
+                id = 0,
+                userId = 1L,
+                userCouponId = null,
+                status = OrderStatus.PENDING,
+                totalPrice = 1000L
+            )
+        )
+        orderItemRepository.saveAll(
+            listOf(
+                OrderItem(
+                    orderId = order.id!!,
+                    productId = 999L,
+                    price = 1000L,
+                    quantity = 1,
+                    LocalDateTime.now()
+                )
+            )
+        ) //없음
+        userPointRepository.save(UserPoint(id = 0, userId = 1L, point = 2000L))
+
+        //when & then
+        val command = PaymentCommand(orderId = order.id!!)
+        assertThatThrownBy {
+            paymentService.create(command)
+        }.isInstanceOf(NoSuchElementException::class.java)
+    }
+
+
+    @Test
+    fun `재고가 부족하면 결제 시 예외가 발생한다`() {
+        //given
+        val product = productRepository.save(
+            Product(id = 0, name = "상품", price = 1000L, quantity = 0)
+        ) // 재고 부족
+
+        val order = orderRepository.save(
+            Order(
+                id = 0,
+                userId = 1L,
+                userCouponId = null,
+                status = OrderStatus.PENDING,
+                totalPrice = 1000L
+            )
+        )
+        orderItemRepository.saveAll(
+            listOf(
+                OrderItem(
+                    orderId = order.id!!,
+                    productId = product.id,
+                    price = 1000L,
+                    quantity = 1,
+                    LocalDateTime.now()
+                )
+            )
+        )
+        userPointRepository.save(UserPoint(id = 0, userId = 1L, point = 2000L))
+
+        //when & then
+        val command = PaymentCommand(orderId = order.id!!)
+        assertThatThrownBy {
+            paymentService.create(command)
+        }.isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun `존재하지 않는 쿠폰 ID로 결제 시 예외가 발생한다`() {
+        //given
+        val product = productRepository.save(
+            Product(id = 0, name = "상품", price = 1000L, quantity = 10)
+        )
+
+        val order = orderRepository.save(
+            Order(
+                id = 0,
+                userId = 1L,
+                userCouponId = 999L, //없는 쿠폰
+                status = OrderStatus.PENDING,
+                totalPrice = 1000L
+            )
+        )
+        orderItemRepository.saveAll(
+            listOf(
+                OrderItem(
+                    orderId = order.id!!,
+                    productId = product.id,
+                    price = 1000L,
+                    quantity = 1,
+                    LocalDateTime.now()
+                )
+            )
+        )
+        userPointRepository.save(UserPoint(id = 0, userId = 1L, point = 2000L))
+
+        //when & then
+        val command = PaymentCommand(orderId = order.id!!)
+        assertThatThrownBy {
+            paymentService.create(command)
+        }.isInstanceOf(NoSuchElementException::class.java)
+    }
+
+
+    @Test
+    fun `이미 사용된 쿠폰으로 결제 시 예외가 발생한다`() {
+        //given
+        val product = productRepository.save(
+            Product(id = 0, name = "상품", price = 1000L, quantity = 10)
+        )
+
+        val userCoupon = userCouponRepository.save(
+            UserCoupon(
+                userCouponId = 0,
+                userId = 1L,
+                couponId = 1L,
+                couponStatus = CouponStatus.USED, //사용 쿠폰
+                issuedAt = LocalDateTime.now().minusDays(1),
+                usedAt = LocalDateTime.now()
+            )
+        )
+
+        val order = orderRepository.save(
+            Order(
+                id = 0,
+                userId = 1L,
+                userCouponId = userCoupon.userCouponId,
+                status = OrderStatus.PENDING,
+                totalPrice = 1000L
+            )
+        )
+        orderItemRepository.saveAll(
+            listOf(
+                OrderItem(
+                    orderId = order.id!!,
+                    productId = product.id,
+                    price = 1000L,
+                    quantity = 1,
+                    LocalDateTime.now()
+                )
+            )
+        )
+        userPointRepository.save(UserPoint(id = 0, userId = 1L, point = 2000L))
+
+        //when & then
+        val command = PaymentCommand(orderId = order.id!!)
+        assertThatThrownBy {
+            paymentService.create(command)
+        }.isInstanceOf(IllegalStateException::class.java)
+
+    }
+
+
+    @Test
+    fun `만료된 쿠폰으로 결제 시 예외가 발생한다`() {
+        //given
+        val product = productRepository.save(
+            Product(id = 0, name = "상품", price = 1000L, quantity = 10)
+        )
+
+        val userCoupon = userCouponRepository.save(
+            UserCoupon(
+                userCouponId = 0,
+                userId = 1L,
+                couponId = 1L,
+                couponStatus = CouponStatus.EXPIRED, //사용 쿠폰
+                issuedAt = LocalDateTime.now().minusDays(50),
+                usedAt = null
+            )
+        )
+
+        val order = orderRepository.save(
+            Order(
+                id = 0,
+                userId = 1L,
+                userCouponId = userCoupon.userCouponId,
+                status = OrderStatus.PENDING,
+                totalPrice = 1000L
+            )
+        )
+        orderItemRepository.saveAll(
+            listOf(
+                OrderItem(
+                    orderId = order.id!!,
+                    productId = product.id,
+                    price = 1000L,
+                    quantity = 1,
+                    LocalDateTime.now()
+                )
+            )
+        )
+        userPointRepository.save(UserPoint(id = 0, userId = 1L, point = 2000L))
+
+        //when & then
+        val command = PaymentCommand(orderId = order.id!!)
+        assertThatThrownBy {
+            paymentService.create(command)
+        }.isInstanceOf(IllegalStateException::class.java)
+
+    }
+
+
+    @Test
+    fun `포인트가 부족하면 결제 시 예외가 발생한다`() {
+        //given
+        val product = productRepository.save(Product(id = 0, name = "상품", price = 2000L, quantity = 1))
+
+        val coupon = couponRepository.save(
+            Coupon(
+                couponId = 0,
+                "선착순 쿠폰",
+                1000,
+                100,
+                LocalDateTime.now().plusDays(1)
+            )
+        )
+
+        val userCoupon = userCouponRepository.save(
+            UserCoupon(
+                userCouponId = 0,
+                userId = 1L,
+                couponId = coupon.couponId,
+                couponStatus = CouponStatus.AVAILABLE, //사용 쿠폰
+                issuedAt = LocalDateTime.now(),
+                usedAt = null
+            )
+        )
+        val order = orderRepository.save(
+            Order(
+                id = 0,
+                userId = 1L,
+                userCouponId = userCoupon.userCouponId,
+                status = OrderStatus.PENDING,
+                totalPrice = 2000L
+            )
+        )
+        orderItemRepository.saveAll(
+            listOf(
+                OrderItem(
+                    orderId = order.id!!,
+                    productId = product.id,
+                    price = 2000L, quantity = 1,
+                    LocalDateTime.now()
+                )
+            )
+        )
+        userPointRepository.save(UserPoint(id = 0, userId = 1L, point = 500L)) //포인트 부족
+
+        //when & then
+        val command = PaymentCommand(orderId = order.id!!)
+        assertThatThrownBy {
+            paymentService.create(command)
+        }.isInstanceOf(IllegalStateException::class.java)
+
+    }
+
+
+    @Test
+    fun `정상적으로 결제가 완료된다`() {
+        // given
+        val product = productRepository.save(
+            Product(id = 0, name = "상품", price = 2000L, quantity = 10)
+        )
+        val coupon = couponRepository.save(
+            Coupon(
+                couponId = 0,
+                "선착순 쿠폰",
+                1000,
+                100,
+                LocalDateTime.now().plusDays(1)
+            )
+        )
+
+        val userCoupon = userCouponRepository.save(
+            UserCoupon(
+                userCouponId = 0,
+                userId = 1L,
+                couponId = coupon.couponId,
+                couponStatus = CouponStatus.AVAILABLE,
+                issuedAt = LocalDateTime.now().minusDays(1),
+                usedAt = null
+            )
+        )
+
+        val order = orderRepository.save(
+            Order(
+                id = 0,
+                userId = 1L,
+                userCouponId = userCoupon.userCouponId,
+                status = OrderStatus.PENDING,
+                totalPrice = 2000L
+            )
+        )
+
+        orderItemRepository.saveAll(
+            listOf(
+                OrderItem(
+                    orderId = order.id!!,
+                    productId = product.id,
+                    price = 2000L,
+                    quantity = 1,
+                    createdAt = LocalDateTime.now()
+                )
+            )
+        )
+
+        userPointRepository.save(UserPoint(id = 0, userId = 1L, point = 1000L))
+
+        // when
+        val command = PaymentCommand(orderId = order.id)
+        val paymentId = paymentService.create(command) // 성공
+
+        // then
+        val updatedOrder = orderRepository.findById(order.id)
+        val updatedProduct = productRepository.findById(product.id)
+        val updatedPoint = userPointRepository.findByUserId(1L)
+        val updatedCoupon = userCouponRepository.findById(userCoupon.userCouponId)
+
+        assertThat(paymentId).isNotNull()
+        assertThat(updatedOrder.status).isEqualTo(OrderStatus.COMPLETED)
+        assertThat(updatedProduct.quantity).isEqualTo(9) // 1개 차감
+        assertThat(updatedPoint.point).isEqualTo(0)      // 1000 포인트 사용
+        assertThat(updatedCoupon.couponStatus).isEqualTo(CouponStatus.USED)
+    }
+
+
+}

--- a/src/test/java/kr/hhplus/be/server/point/PointConcurrentTest.kt
+++ b/src/test/java/kr/hhplus/be/server/point/PointConcurrentTest.kt
@@ -1,0 +1,38 @@
+package kr.hhplus.be.server.point
+
+import kr.hhplus.be.server.application.point.PointChargeCommand
+import kr.hhplus.be.server.application.point.PointService
+import kr.hhplus.be.server.domain.point.UserPoint
+import kr.hhplus.be.server.domain.point.UserPointRepository
+import kr.hhplus.be.server.support.IntegrationTestBase
+import kr.hhplus.be.server.support.TestFixtures
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class PointConcurrentTest @Autowired constructor(
+    private val pointService: PointService,
+    private val pointRepository: UserPointRepository
+) : IntegrationTestBase() {
+
+    @Test
+    fun `동시에 포인트를 충전하면 최종 포인트가 예상과 다를 수 있다`() {
+        val userId = 1L
+        pointRepository.save(UserPoint(id = 0, userId = userId, point = 0))
+
+        TestFixtures.runConcurrently(100, Runnable {
+            try {
+                pointService.charge(PointChargeCommand(userId, 10))
+            } catch (e: Exception) {
+                println("에러 발생: ${e.javaClass.simpleName} - ${e.message}")
+            }
+        })
+
+        val finalPoint = pointRepository.findByUserId(userId)!!.point
+        println("최종 포인트: $finalPoint")
+
+        //의도적으로 실패: 기대값은 10 * 100 = 1000
+        assertThat(finalPoint).isEqualTo(1000)
+    }
+
+}

--- a/src/test/java/kr/hhplus/be/server/point/PointServiceIntegrationTest.kt
+++ b/src/test/java/kr/hhplus/be/server/point/PointServiceIntegrationTest.kt
@@ -1,0 +1,70 @@
+package kr.hhplus.be.server.point
+
+import kr.hhplus.be.server.application.point.PointChargeCommand
+import kr.hhplus.be.server.application.point.PointService
+import kr.hhplus.be.server.domain.point.UserPoint
+import kr.hhplus.be.server.domain.point.UserPointRepository
+import kr.hhplus.be.server.support.IntegrationTestBase
+import kr.hhplus.be.server.support.TestFixtures
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+
+class PointServiceIntegrationTest @Autowired constructor(
+    private val pointService: PointService,
+    private val pointRepository: UserPointRepository
+) : IntegrationTestBase() {
+
+
+    @Test
+    fun `포인트 충전이 정상적으로 수행된다`() {
+        // given
+        pointRepository.save(
+            TestFixtures.userPoint(userId = 1, point = 1000)
+        )
+        val command = PointChargeCommand(userId = 1L, amount = 500)
+
+        // when
+        val result = pointService.charge(command)
+
+        // then
+        assertThat(result.point).isEqualTo(1500)
+    }
+
+    @Test
+    fun `유저 아이디로 포인트를 조회한다`() {
+        //given
+        pointRepository.save(
+            TestFixtures.userPoint(userId = 1, point = 1000)
+        )
+        val userId = 1L
+
+        //when
+        val result = pointService.getPoint(userId)
+
+        //then
+        assertThat(result.userId).isEqualTo(userId)
+    }
+
+    @Test
+    fun `동시에 포인트를 충전하면 최종 포인트가 예상과 다를 수 있다`() {
+        val userId = 1L
+        pointRepository.save(UserPoint(id = 0, userId = userId, point = 0))
+
+        TestFixtures.runConcurrently(100, Runnable {
+            try {
+                pointService.charge(PointChargeCommand(userId, 10))
+            } catch (e: Exception) {
+                println("에러 발생: ${e.javaClass.simpleName} - ${e.message}")
+            }
+        })
+
+        val finalPoint = pointRepository.findByUserId(userId)!!.point
+        println("최종 포인트: $finalPoint")
+
+        //의도적으로 실패: 기대값은 10 * 100 = 1000
+        assertThat(finalPoint).isEqualTo(1000)
+    }
+
+}

--- a/src/test/java/kr/hhplus/be/server/product/ProductServiceIntegrationTest.kt
+++ b/src/test/java/kr/hhplus/be/server/product/ProductServiceIntegrationTest.kt
@@ -1,0 +1,81 @@
+package kr.hhplus.be.server.product
+
+import kr.hhplus.be.server.application.product.ProductService
+import kr.hhplus.be.server.domain.order.OrderItem
+import kr.hhplus.be.server.domain.order.OrderItemRepository
+import kr.hhplus.be.server.domain.product.Product
+import kr.hhplus.be.server.domain.product.ProductRepository
+import kr.hhplus.be.server.support.IntegrationTestBase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDateTime
+
+
+class ProductServiceIntegrationTest @Autowired constructor(
+    private val productService: ProductService,
+    private val productRepository: ProductRepository,
+    private val orderItemRepository: OrderItemRepository,
+) : IntegrationTestBase() {
+
+    @Test
+    fun `상품 목록을 조회한다`() {
+        //given
+        val products = (1..100).map {
+            Product(
+                id = it.toLong(),
+                name = "상품$it",
+                price = it.toLong(),
+                quantity = (it * 1000)
+            )
+        }
+        products.forEach(productRepository::save)
+
+        //when
+        val result = productService.findAllProducts()
+
+        //then
+        println(result.size)
+
+        assertThat(result).hasSize(100)
+    }
+
+    @Test
+    fun `인기 상품(판매량 기준 상위 5개 조회 시점)을 조회 한다`() {
+        //given
+        // 상품 저장
+        val products = (1..100).map {
+            Product(
+                id = it.toLong(),
+                name = "상품$it",
+                price = it.toLong(),
+                quantity = (it * 1000)
+            )
+        }
+        products.forEach(productRepository::save)
+
+        // 최근 3일 내 주문 생성
+        val now = LocalDateTime.now()
+        val orderItems = listOf(
+            1L to 10, 2L to 20, 3L to 30, 4L to 25, 5L to 15, 6L to 5
+        ).map { (productId, qty) ->
+            OrderItem(
+                orderId = 0,
+                productId = productId,
+                price = 1000,
+                quantity = qty,
+                createdAt = now.minusDays(1)
+            )
+        }
+        orderItemRepository.saveAll(orderItems)
+
+        //when
+        val result = productService.findRankingByProducts()
+
+        //then
+        println(result.size)
+        assertThat(result).hasSize(5)
+    }
+
+
+}

--- a/src/test/java/kr/hhplus/be/server/support/IntegrationTestBase.kt
+++ b/src/test/java/kr/hhplus/be/server/support/IntegrationTestBase.kt
@@ -1,0 +1,56 @@
+package kr.hhplus.be.server.support
+
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+
+
+@SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
+abstract class IntegrationTestBase {
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @BeforeEach
+    fun cleanDatabase() {
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0")
+
+        val tableNames = jdbcTemplate.queryForList(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = (SELECT DATABASE())",
+            String::class.java
+        )
+
+        tableNames.forEach { tableName ->
+            jdbcTemplate.execute("TRUNCATE TABLE $tableName")
+        }
+
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1")
+    }
+
+    companion object {
+        @Container
+        val mysql = MySQLContainer(DockerImageName.parse("mysql:8.0")).apply {
+            withDatabaseName("hhplus")
+            withUsername("application")
+            withPassword("application")
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun overrideProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", mysql::getJdbcUrl)
+            registry.add("spring.datasource.username", mysql::getUsername)
+            registry.add("spring.datasource.password", mysql::getPassword)
+        }
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,11 @@
+spring:
+  spring:
+    datasource:
+      url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
+      username: application
+      password: application
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    open-in-view: false


### PR DESCRIPTION
### **커밋 링크**

인프라 계층에서 도메인 객체와 JPA 구현체를 분리하여 작성하였습니다.
고수준이 저수준에 의존하지 않는 걸 생각하면서 작성하였습니다.

포인트 통합테스트, 인프라 : 8ee2e6da7697bf5307a58aef1de2fcc3f62acc69
상품 통합테스트, 인프라 : d3c1162a740e2ddf3e1d6e2e9a5c25fa9b23ef96
쿠폰 통합테스트, 인프라 : 79296cfe0cb81febaefe56e63a69e1d17b480022
주문/결제 통합테스트, 인프라 :  1bcba2417fdae701bd14b8e1c1cee8f03d3678d0

인프라계층 구현과 통합테스트 작성을 분리 했어야 했는데, 한번에 올리게 되어서 죄송합니다.

---
### **리뷰 포인트(질문)**
- 현재는 서비스 클래스가 단순하여 facade를 별도로 두지 않고 있습니다.하지만 향후 order, payment 흐름이 복잡해질 것을 고려해 facade 레이어를 추가할 계획인데,이와 같은 점진적인 레이어 확장 전략이 적절한 방향인지, 혹은 초기에 facade를 도입해 두는 것이 더 나았을지 의견 부탁드립니다.
- Product 엔티티에서 재고 차감 책임을 분리하여,Product와 Stock을 별도의 도메인으로 분리하려고 합니다.
작성 중에 보니 Product는 상품 자체의 속성과 책임에 집중하고,재고 관리 로직은 별도의 Aggregate로 분리하는 것이 더 자연스럽다고 판단했는데,이러한 도메인 분리가 설계 관점에서 타당한지, 혹은 오히려 지나친 분해로 작용할 수 있을지 조언 부탁드립니다.

  
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
도메인에 대해서 깊이 있게 고민해본 점

### Problem
<!--개선이 필요한 점-->
시간 분배를 잘 하지 못한 점 
스케줄 관리를 해야하는 점
### Try
<!-- 새롭게 시도할 점 -->
테크니컬 라이팅에 대해서 알아본 점