### PR TITLE
Step12

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,9 +48,13 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+	implementation("org.redisson:redisson-spring-boot-starter:3.37.0") //redisson
 
 	//swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
+
+	implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0")
 
     // DB
 	runtimeOnly("com.mysql:mysql-connector-j")

--- a/docs/레디스 캐시 성능 개선.md
+++ b/docs/레디스 캐시 성능 개선.md
@@ -1,0 +1,101 @@
+
+# Redis 기반 캐싱 전략 적용 및 성능 개선 보고서
+
+##  목적
+- 인기 상품 조회 API에 대한 **성능 병목을 줄이고**, **사용자 응답 속도를 개선**하기 위해 Redis 기반 캐싱 전략을 도입하고, 실제 성능 데이터를 측정하여 효과를 분석한다.
+
+---
+
+##  적용 대상 기능
+
+- **기능명**: 인기 상품 랭킹 조회 API (`/api/v1/products/rank/cache`)
+- **로직 요약**:
+  1. `order_item`, `orders` 테이블을 통해 최근 판매 수량 기준 통계 추출
+  2. `product_id` 기준으로 상품 정보 조회
+  3. 응답 DTO인 `ProductResult` 가공 후 반환
+
+---
+
+##  캐싱 전략 설명
+
+###  1. Read-through 캐시 구조
+
+```kotlin
+@Cacheable(cacheNames = ["popularProducts"], key = "'ranking'")
+fun findRankingByProductsCache(): List<ProductResult>
+```
+
+- 최초 요청 시 DB에서 데이터를 조회하고 Redis에 저장
+- 이후 요청은 Redis에서 바로 조회하여 DB 부하 감소 및 응답속도 개선
+
+---
+
+### 2. 주기적 Cache 갱신 전략 (Scheduler + CachePut)
+
+```kotlin
+@Scheduled(cron = "0 59 23 * * *")
+@CachePut(cacheNames = ["popularProducts"], key = "'ranking'")
+fun updatePopularProducts(): List<ProductResult> {
+    ...
+}
+```
+
+- 매일 23:59에 캐시를 **TTL과 무관하게 최신 데이터로 강제 덮어씀**
+- `@Scheduled` + `@CachePut` 조합을 사용하여 비동기적으로 캐시 동기화 수행
+
+---
+
+## 성능 비교 결과
+```
+테스트 코드 결과
+Hibernate: insert into products (name,price,quantity) values (?,?,?)
+Hibernate: insert into products (name,price,quantity) values (?,?,?)
+Hibernate: insert into orders (status,total_price,user_coupon_id,user_id) values (?,?,?,?)
+Hibernate: insert into orders (status,total_price,user_coupon_id,user_id) values (?,?,?,?)
+Hibernate: insert into orders (status,total_price,user_coupon_id,user_id) values (?,?,?,?)
+Hibernate: insert into orders (status,total_price,user_coupon_id,user_id) values (?,?,?,?)
+Hibernate: insert into order_item (created_at,order_id,price,product_id,quantity) values (?,?,?,?,?)
+Hibernate: insert into order_item (created_at,order_id,price,product_id,quantity) values (?,?,?,?,?)
+Hibernate: insert into order_item (created_at,order_id,price,product_id,quantity) values (?,?,?,?,?)
+Hibernate: insert into order_item (created_at,order_id,price,product_id,quantity) values (?,?,?,?,?)
+Hibernate: insert into order_item (created_at,order_id,price,product_id,quantity) values (?,?,?,?,?)
+2025-05-08T18:28:40.416Z  INFO 52903 --- [hhplus] [o-auto-1-exec-1] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring DispatcherServlet 'dispatcherServlet'
+2025-05-08T18:28:40.416Z  INFO 52903 --- [hhplus] [o-auto-1-exec-1] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
+2025-05-08T18:28:40.417Z  INFO 52903 --- [hhplus] [o-auto-1-exec-1] o.s.web.servlet.DispatcherServlet        : Completed initialization in 1 ms
+Hibernate: select oie1_0.product_id,sum(oie1_0.quantity) from order_item oie1_0,orders oe1_0 where oe1_0.id=oie1_0.order_id and oe1_0.status='COMPLETED' and oie1_0.created_at>=? group by oie1_0.product_id order by sum(oie1_0.quantity) desc limit ?
+Hibernate: select pe1_0.id,pe1_0.name,pe1_0.price,pe1_0.quantity from products pe1_0 where pe1_0.id in (?,?)
+첫 요청 (캐시 미적중): 300ms
+두 번째 요청 (캐시 적중): 13ms
+```
+
+| 구분                  | 평균 응답 시간 |
+|---------------------|----------------|
+| 첫 요청 (캐시 미적중) | 약 **300ms**    |
+| 두 번째 요청 (캐시 적중) | 약 **13ms**     |
+
+- **약 95.6% 응답 시간 단축** (23배 이상 개선)
+- 캐시 적중 시 DB 조회 쿼리가 완전히 제거되어 시스템 부하 절감
+
+---
+
+## 테스트 환경
+- Redis 7.4 (Testcontainers 기반 테스트 환경)
+- Hibernate + MySQL 8.0
+
+
+---
+
+##  기대 효과
+
+- **고빈도 호출되는 인기상품 조회 API의 응답시간을 최소화**
+- 정기 갱신(스케줄링)으로 **캐시 일관성 확보**
+- 캐시 미스 발생률 최소화
+- 향후 캐시 분산 및 멀티 키 전략으로 확장 가능
+
+---
+
+## 결론 및 개선점
+
+- 현재 전략은 **정적 조회성 데이터를 효율적으로 캐시**하는 대표적인 Read-through + CachePut 구조이다.
+- 이후 개선 방향:
+  - 인기상품 기준 다변화 시 `key = "'ranking:' + #기간"` 형태로 세분화

--- a/src/main/kotlin/kr/hhplus/be/server/application/facade/PaymentFacade.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/facade/PaymentFacade.kt
@@ -1,0 +1,36 @@
+package kr.hhplus.be.server.application.facade
+
+
+import kr.hhplus.be.server.application.payment.PaymentCommand
+import kr.hhplus.be.server.application.payment.PaymentService
+import kr.hhplus.be.server.domain.order.OrderItemRepository
+import kr.hhplus.be.server.domain.order.OrderRepository
+import org.springframework.stereotype.Service
+
+@Service
+class PaymentFacade(
+    private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository,
+    private val paymentService: PaymentService
+) {
+
+    fun productDecreaseSpinLock(paymentCommand: PaymentCommand){
+        val order = orderRepository.findById(paymentCommand.orderId)
+        val orderItems = orderItemRepository.findByOrderId(order.id)
+
+        orderItems.sortedBy { it.productId }.forEach { item -> //데드락 방지를 위한 sort
+            paymentService.decreaseWithSpinLock(item.productId,item.quantity)
+        }
+    }
+
+    fun productDecreasePubSubLock(paymentCommand: PaymentCommand){
+        val order = orderRepository.findById(paymentCommand.orderId)
+        val orderItems = orderItemRepository.findByOrderId(order.id)
+
+        orderItems.sortedBy { it.productId }.forEach { item -> //데드락 방지를 위한 sort
+            paymentService.decreaseWithPubSubLock(item.productId,item.quantity)
+        }
+    }
+
+
+}

--- a/src/main/kotlin/kr/hhplus/be/server/application/lock/DistributedLock.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/lock/DistributedLock.kt
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.application.lock
+
+import java.util.concurrent.TimeUnit
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DistributedLock(
+    val key: String,
+    val timeUnit: TimeUnit = TimeUnit.SECONDS, // 락의 시간 단위
+    val waitTime: Long = 3L, //락 획득 시도 시간
+    val leaseTime: Long = 5L, //락 유지 시간
+    val lockType: LockType = LockType.REDIS_SPIN// 기본 값 SPIN lock
+) {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/application/lock/DistributedLockAspect.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/lock/DistributedLockAspect.kt
@@ -1,0 +1,85 @@
+package kr.hhplus.be.server.application.lock
+
+import kr.hhplus.be.server.infrastructure.lock.DistributedLockExecutor
+import kr.hhplus.be.server.infrastructure.lock.RedisSpinLock
+import kr.hhplus.be.server.infrastructure.lock.RedissonLock
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.redisson.api.RedissonClient
+import org.slf4j.LoggerFactory
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.expression.ExpressionParser
+import org.springframework.expression.spel.standard.SpelExpressionParser
+import org.springframework.expression.spel.support.StandardEvaluationContext
+import org.springframework.stereotype.Component
+import java.lang.reflect.Method
+
+@Aspect
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class DistributedLockAspect(
+    private val redisTemplate: StringRedisTemplate,
+    private val redissonClient: RedissonClient
+){
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Around("@annotation(kr.hhplus.be.server.application.lock.DistributedLock)")
+    fun around(joinPoint: ProceedingJoinPoint): Any? {
+        val methodSignature = joinPoint.signature as MethodSignature
+        val method = methodSignature.method
+        val lock = method.getAnnotation(DistributedLock::class.java)
+
+        val lockKey = resolveKey(
+            lock.key,
+            method,
+            joinPoint.args,
+            methodSignature.parameterNames
+        )
+
+        val distributedLock: DistributedLockExecutor = when (lock.lockType) {
+            LockType.REDIS_SPIN -> RedisSpinLock(
+                redisTemplate,
+                lockKey,
+                lock.waitTime,
+                lock.leaseTime,
+                lock.timeUnit
+            )
+            LockType.REDIS_PUB_SUB -> RedissonLock(
+                redissonClient,
+                lockKey,
+                lock.waitTime,
+                lock.leaseTime,
+                lock.timeUnit
+            )
+        }
+        log.info("[AOP] Lock 시도 - key=$lockKey, type=${lock.lockType}")
+        if (!distributedLock.lock()) {
+            log.warn("[AOP] Lock 실패 - key=$lockKey")
+            throw IllegalStateException("분산락 획득 실패: key=$lockKey")
+        }
+
+        try {
+            log.info("[AOP] Lock 성공 - key=$lockKey")
+            return joinPoint.proceed()
+        } finally {
+            distributedLock.unlock()
+            log.info("[AOP] Lock 해제 - key=$lockKey")
+        }
+    }
+
+    private fun resolveKey(keyExpression: String, method: Method, args: Array<Any?>, parameterNames: Array<String>): String {
+        val parser: ExpressionParser = SpelExpressionParser()
+        val context = StandardEvaluationContext()
+
+        parameterNames.forEachIndexed { index, name ->
+            context.setVariable(name, args[index])
+        }
+
+        val evaluatedKey = parser.parseExpression(keyExpression).getValue(context, String::class.java)
+        return "lock:$evaluatedKey"
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/application/lock/LockType.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/lock/LockType.kt
@@ -1,0 +1,6 @@
+package kr.hhplus.be.server.application.lock
+
+enum class LockType {
+    REDIS_SPIN,
+    REDIS_PUB_SUB
+}

--- a/src/main/kotlin/kr/hhplus/be/server/application/product/ProductScheduler.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/product/ProductScheduler.kt
@@ -1,0 +1,25 @@
+package kr.hhplus.be.server.application.product
+
+import kr.hhplus.be.server.domain.product.ProductRepository
+import kr.hhplus.be.server.domain.stat.StatRepository
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.cache.annotation.CachePut
+
+@Component
+class ProductScheduler(
+    private val statRepository: StatRepository,
+    private val productRepository: ProductRepository
+) {
+
+    // 매일 23:59에 캐시 갱신 (TTL 무관하게 최신 데이터로 덮어쓰기)
+    @Scheduled(cron = "0 59 23 * * *")
+    @CachePut(cacheNames = ["popularProducts"], key = "'ranking'")
+    fun updatePopularProducts(): List<ProductResult> {
+        val stats = statRepository.findAllOrderBySalesDesc()
+        val ids = stats.map { it.productId }.distinct()
+        val products = productRepository.findByIds(ids)
+        val productMap = products.associateBy { it.id }
+        return ProductResult.from(productMap, stats)
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/application/product/ProductService.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/product/ProductService.kt
@@ -3,6 +3,7 @@ package kr.hhplus.be.server.application.product
 import kr.hhplus.be.server.domain.product.Product
 import kr.hhplus.be.server.domain.product.ProductRepository
 import kr.hhplus.be.server.domain.stat.StatRepository
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 
 @Service
@@ -25,5 +26,14 @@ class ProductService(
         val productMap = products.associateBy { it.id }
 
         return ProductResult.from(productMap,stats)
+    }
+
+    @Cacheable(cacheNames = ["popularProducts"],key = "'ranking'")
+    fun findRankingByProductsCache(): List<ProductResult> {
+        val stats = statRepository.findAllOrderBySalesDesc()
+        val ids = stats.map { it.productId }.distinct()
+        val products = productRepository.findByIds(ids)
+        val productMap = products.associateBy { it.id }
+        return ProductResult.from(productMap, stats)
     }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/config/redis/RedisConfig.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/config/redis/RedisConfig.kt
@@ -1,0 +1,56 @@
+package kr.hhplus.be.server.config.redis
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.RedisSerializer
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class RedisConfig {
+
+    @Bean
+    fun cacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
+        val defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofHours(1L))
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer())) // 키를 문자열로 직렬화
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    redisSerializer()
+                )
+            )
+            .disableCachingNullValues()
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+            .cacheDefaults(defaultCacheConfig)
+            .build()
+    }
+
+    fun redisSerializer(): RedisSerializer<Any> {
+        val objectMapper = ObjectMapper()
+            .registerKotlinModule()                        // Kotlin data class 역직렬화 지원
+            .registerModule(JavaTimeModule())     // LocalDateTime 등 지원
+            .activateDefaultTyping(                        // 형성 역직렬화 지원 (List<ProductResult> 가능하게 함)
+                BasicPolymorphicTypeValidator.builder()
+                    .allowIfBaseType(Any::class.java).build(),
+                ObjectMapper.DefaultTyping.NON_FINAL
+            )
+
+        return GenericJackson2JsonRedisSerializer(objectMapper)
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/lock/DistributedLockExecutor.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/lock/DistributedLockExecutor.kt
@@ -1,0 +1,6 @@
+package kr.hhplus.be.server.infrastructure.lock
+
+interface DistributedLockExecutor {
+    fun lock(): Boolean
+    fun unlock()
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/lock/RedisSpinLock.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/lock/RedisSpinLock.kt
@@ -1,0 +1,46 @@
+package kr.hhplus.be.server.infrastructure.lock
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+
+class RedisSpinLock(
+    private val redisTemplate: StringRedisTemplate,
+    private val lockKey: String,
+    private val waitTime: Long,
+    private val leaseTime: Long,
+    private val timeUnit: TimeUnit,
+): DistributedLockExecutor {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val lockValue = UUID.randomUUID().toString()
+
+    override fun lock(): Boolean {
+        val deadline = System.currentTimeMillis() + timeUnit.toMillis(waitTime)
+
+        while (System.currentTimeMillis() < deadline) {
+            log.info("SPIN LOCK: 락 획득 시도 - key=$lockKey (value=$lockValue)")
+
+            val success = redisTemplate.opsForValue()
+                .setIfAbsent(lockKey, lockValue, leaseTime, timeUnit)
+
+            if (success == true) {
+                log.info("SPIN LOCK: 락 획득 성공 - key=$lockKey (value=$lockValue)")
+                return true
+            }
+
+            log.info("SPIN LOCK:  락 획득 대기중 - key=$lockKey (value=$lockValue)")
+            Thread.sleep(100)
+        }
+        log.warn("SPIN LOCK: 락 획득 실패, 대기 시간 초과 - key=$lockKey (value=$lockValue)")
+        return false
+    }
+
+
+    override fun unlock() {
+        if(redisTemplate.opsForValue().get(lockKey) == lockValue) {
+            redisTemplate.delete(lockKey)
+        }
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/lock/RedissonLock.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/lock/RedissonLock.kt
@@ -1,0 +1,39 @@
+package kr.hhplus.be.server.infrastructure.lock
+
+import org.redisson.api.RedissonClient
+import org.slf4j.LoggerFactory
+import java.util.concurrent.TimeUnit
+
+class RedissonLock(
+    private val redissonClient: RedissonClient,
+    private val lockKey: String,
+    private val waitTime: Long,
+    private val leaseTime: Long,
+    private val timeUnit: TimeUnit,
+): DistributedLockExecutor {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun lock(): Boolean {
+        log.info("REDISSON LOCK: 락 획득 시도 - key=$lockKey")
+        val lock = redissonClient.getLock(lockKey)
+        val success = lock.tryLock(waitTime, leaseTime, timeUnit)
+
+        if(success) {
+            log.info("REDISSON LOCK: 락 획득 성공 - key=$lockKey")
+        }else{
+            log.warn("REDISSON LOCK: 락 획득 실패 - key=$lockKey")
+        }
+
+        return success
+    }
+
+
+    override fun unlock() {
+        val lock = redissonClient.getLock(lockKey)
+        if(lock.isHeldByCurrentThread){
+            lock.unlock()
+            log.info("REDISSON LOCK 락 해제 완료 - key=$lockKey")
+        }
+    }
+
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/stat/JpaStatQueryRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/stat/JpaStatQueryRepository.kt
@@ -13,8 +13,10 @@ interface JpaStatQueryRepository: JpaRepository<OrderItemEntity, Long> {
         SELECT new kr.hhplus.be.server.infrastructure.stat.ProductStatDto(
             orderItem.productId, SUM(orderItem.quantity)
         )
-        FROM OrderItemEntity orderItem
-        WHERE orderItem.createdAt >= :threeDaysAgo
+        FROM OrderItemEntity orderItem, OrderEntity order
+        WHERE order.id = orderItem.orderId
+        AND order.status = 'COMPLETED'
+        AND orderItem.createdAt >= :threeDaysAgo
         GROUP BY orderItem.productId
         ORDER BY SUM(orderItem.quantity) DESC
     """)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,15 @@ spring:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC
 
+  cache:
+    type: redis
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+
+
 springdoc:
   swagger-ui:
     operations-sorter: method

--- a/src/test/java/kr/hhplus/be/server/payment/PaymentDistributedLockTest.kt
+++ b/src/test/java/kr/hhplus/be/server/payment/PaymentDistributedLockTest.kt
@@ -1,0 +1,309 @@
+package kr.hhplus.be.server.payment
+
+import kr.hhplus.be.server.application.facade.PaymentFacade
+import kr.hhplus.be.server.application.payment.PaymentCommand
+import kr.hhplus.be.server.application.payment.PaymentService
+import kr.hhplus.be.server.domain.coupon.Coupon
+import kr.hhplus.be.server.domain.coupon.CouponRepository
+import kr.hhplus.be.server.domain.coupon.CouponStatus
+import kr.hhplus.be.server.domain.coupon.UserCoupon
+import kr.hhplus.be.server.domain.coupon.UserCouponRepository
+import kr.hhplus.be.server.domain.order.Order
+import kr.hhplus.be.server.domain.order.OrderItem
+import kr.hhplus.be.server.domain.order.OrderItemRepository
+import kr.hhplus.be.server.domain.order.OrderRepository
+import kr.hhplus.be.server.domain.order.OrderStatus
+import kr.hhplus.be.server.domain.payment.Payment
+import kr.hhplus.be.server.domain.point.UserPoint
+import kr.hhplus.be.server.domain.point.UserPointRepository
+import kr.hhplus.be.server.domain.product.Product
+import kr.hhplus.be.server.domain.product.ProductRepository
+import kr.hhplus.be.server.support.IntegrationTestBase
+import kr.hhplus.be.server.support.TestFixtures
+import org.springframework.context.ApplicationContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDateTime
+import java.util.Collections
+
+class PaymentDistributedLockTest @Autowired constructor(
+    private val paymentFacade: PaymentFacade,
+    private val productRepository: ProductRepository,
+    private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository,
+    private val applicationContext: ApplicationContext,
+    private val couponRepository: CouponRepository,
+    private val userCouponRepository: UserCouponRepository,
+    private val userPointRepository: UserPointRepository,
+    private val paymentService: PaymentService,
+) : IntegrationTestBase() {
+
+    @DisplayName("aop 등록 여부 확인")
+    @Test
+    fun checkDistributedLockAspect() {
+        val beans = applicationContext.getBeansOfType(Class.forName("kr.hhplus.be.server.application.lock.DistributedLockAspect"))
+        println("DistributedLockAspect 등록 여부: ${beans.keys}")
+    }
+
+
+    @Test
+    fun `spin lock 적용 시 - 2번 동시 요청이 들어왔을때 정상적으로 결제가 완료된다`() {
+        // given
+        val product = productRepository.save(
+            Product(id = 0, name = "상품", price = 2000L, quantity = 10)
+        )
+        val coupon = couponRepository.save(
+            Coupon(
+                couponId = 0,
+                "선착순 쿠폰",
+                1000,
+                100,
+                LocalDateTime.now().plusDays(1)
+            )
+        )
+
+        val userCoupon = userCouponRepository.save(
+            UserCoupon(
+                userCouponId = 0,
+                userId = 1L,
+                couponId = coupon.couponId,
+                couponStatus = CouponStatus.AVAILABLE,
+                issuedAt = LocalDateTime.now().minusDays(1),
+                usedAt = null
+            )
+        )
+
+        val order = orderRepository.save(
+            Order(
+                id = 0,
+                userId = 1L,
+                userCouponId = userCoupon.userCouponId,
+                status = OrderStatus.PENDING,
+                totalPrice = 2000L
+            )
+        )
+
+        orderItemRepository.saveAll(
+            listOf(
+                OrderItem(
+                    orderId = order.id!!,
+                    productId = product.id,
+                    price = 2000L,
+                    quantity = 1,
+                    createdAt = LocalDateTime.now()
+                )
+            )
+        )
+
+        userPointRepository.save(UserPoint(id = 0, userId = 1L, point = 1000L,0))
+
+        // when
+        val failures = Collections.synchronizedList(mutableListOf<Throwable>())
+        var paymentId: Payment? = null
+        TestFixtures.runConcurrently(2) {
+            try {
+                val command = PaymentCommand(orderId = order.id)
+                paymentId = paymentService.createPessimistic(command) // 성공
+            } catch (e: Exception) {
+                failures.add(e)
+            }
+        }
+
+
+        // then
+        val updatedOrder = orderRepository.findById(order.id)
+        val updatedProduct = productRepository.findById(product.id)
+        val updatedPoint = userPointRepository.findByUserId(1L)
+        val updatedCoupon = userCouponRepository.findById(userCoupon.userCouponId)
+
+        assertThat(paymentId).isNotNull()
+        assertThat(updatedOrder.status).isEqualTo(OrderStatus.COMPLETED)
+        assertThat(updatedProduct.quantity).isEqualTo(9) // 1개 차감
+        assertThat(updatedPoint.point).isEqualTo(0)      // 1000 포인트 사용
+        assertThat(updatedCoupon.couponStatus).isEqualTo(CouponStatus.USED)
+    }
+
+
+    @Test
+    fun `spin lock 적용시 동일한 productId(재고가 10개)에 대해 동시에 요청이 5개 들어왔을때 5개 성공한다`() {
+        // given
+        val product = productRepository.save(Product(0, "상품1", 1000, 10))
+
+        val order = orderRepository.save(
+            Order(
+                id = 0,
+                userId = 1L,
+                userCouponId = null,
+                status = OrderStatus.PENDING,
+                totalPrice = 1000L
+            )
+        )
+        orderItemRepository.saveAll(
+            listOf(
+                OrderItem(
+                    orderId = order.id!!,
+                    productId = product.id,
+                    price = 1000L,
+                    quantity = 1,
+                    LocalDateTime.now()
+                )
+            )
+        )
+
+        val failures = Collections.synchronizedList(mutableListOf<Throwable>())
+
+        TestFixtures.runConcurrently(5) {
+            try {
+                val command = PaymentCommand(orderId = order.id)
+                paymentFacade.productDecreaseSpinLock(command)
+            } catch (e: Exception) {
+                failures.add(e)
+            }
+        }
+
+        // then
+        val updatedProduct = productRepository.findById(product.id)
+        assertThat(updatedProduct.quantity).isEqualTo(5)
+        assertThat(failures.size).isEqualTo(0)
+    }
+
+
+    @Test
+    fun `spin lock 적용시 동일한 productId(재고가 10개)에 대해 동시에 요청이 15개 들어왔을때 10개 성공하고 5개는 실패한다`() {
+        // given
+        val product = productRepository.save(Product(0, "상품1", 1000, 10))
+
+        val order = orderRepository.save(
+            Order(
+                id = 0,
+                userId = 1L,
+                userCouponId = null,
+                status = OrderStatus.PENDING,
+                totalPrice = 1000L
+            )
+        )
+        orderItemRepository.saveAll(
+            listOf(
+                OrderItem(
+                    orderId = order.id!!,
+                    productId = product.id,
+                    price = 1000L,
+                    quantity = 1,
+                    LocalDateTime.now()
+                )
+            )
+        )
+
+        val failures = Collections.synchronizedList(mutableListOf<Throwable>())
+
+        TestFixtures.runConcurrently(15) {
+            try {
+                val command = PaymentCommand(orderId = order.id)
+                paymentFacade.productDecreaseSpinLock(command)
+            } catch (e: Exception) {
+                failures.add(e)
+            }
+        }
+
+        // then
+        val updatedProduct = productRepository.findById(product.id)
+        assertThat(updatedProduct.quantity).isEqualTo(0)
+        assertThat(failures.size).isEqualTo(5)
+    }
+
+
+
+    @Test
+    fun `pub-sub 락 적용 시 동일한 productId(재고가 10개)에 대해 동시에 요청이 5개 들어왔을때 5개 성공한다`() {
+        // given
+        val product = productRepository.save(Product(0, "상품1", 1000, 10))
+
+        val order = orderRepository.save(
+            Order(
+                id = 0,
+                userId = 1L,
+                userCouponId = null,
+                status = OrderStatus.PENDING,
+                totalPrice = 1000L
+            )
+        )
+        orderItemRepository.saveAll(
+            listOf(
+                OrderItem(
+                    orderId = order.id!!,
+                    productId = product.id,
+                    price = 1000L,
+                    quantity = 1,
+                    LocalDateTime.now()
+                )
+            )
+        )
+
+        val failures = Collections.synchronizedList(mutableListOf<Throwable>())
+
+        TestFixtures.runConcurrently(5) {
+            try {
+                val command = PaymentCommand(orderId = order.id)
+                paymentFacade.productDecreasePubSubLock(command)
+            } catch (e: Exception) {
+                failures.add(e)
+            }
+        }
+
+        // then
+        val updatedProduct = productRepository.findById(product.id)
+        assertThat(updatedProduct.quantity).isEqualTo(5)
+        assertThat(failures.size).isEqualTo(0)
+    }
+
+
+    @Test
+    fun `pub-sub 락 적용 시 동일한 productId(재고가 10개)에 대해 동시에 요청이 15개 들어왔을때 10개 성공하고 5개는 실패한다`() {
+        // given
+        val product = productRepository.save(Product(0, "상품1", 1000, 10))
+
+        val order = orderRepository.save(
+            Order(
+                id = 0,
+                userId = 1L,
+                userCouponId = null,
+                status = OrderStatus.PENDING,
+                totalPrice = 1000L
+            )
+        )
+        orderItemRepository.saveAll(
+            listOf(
+                OrderItem(
+                    orderId = order.id!!,
+                    productId = product.id,
+                    price = 1000L,
+                    quantity = 1,
+                    LocalDateTime.now()
+                )
+            )
+        )
+
+        val failures = Collections.synchronizedList(mutableListOf<Throwable>())
+
+        TestFixtures.runConcurrently(15) {
+            try {
+                val command = PaymentCommand(orderId = order.id)
+                paymentFacade.productDecreasePubSubLock(command)
+            } catch (e: Exception) {
+                failures.add(e)
+            }
+        }
+
+        // then
+        val updatedProduct = productRepository.findById(product.id)
+        assertThat(updatedProduct.quantity).isEqualTo(0)
+        assertThat(failures.size).isEqualTo(5)
+    }
+
+}
+
+
+
+

--- a/src/test/java/kr/hhplus/be/server/product/ProductE2ETest.kt
+++ b/src/test/java/kr/hhplus/be/server/product/ProductE2ETest.kt
@@ -92,4 +92,114 @@ class ProductE2ETest @Autowired constructor(
             assertThat(data[0].name).isEqualTo("상품1")
         })
     }
+
+
+    @Test
+    fun `상품 랭킹 조회 요청 API cache 적용 - 200 OK`() {
+        // given
+        jpaProductRepository.save(ProductEntity(0, "상품1", 1000, 15))
+        jpaProductRepository.save(ProductEntity(0, "상품2", 2000, 5))
+        jpaOrderRepository.save(
+            OrderEntity(
+                id = 0,
+                userId = 1,
+                userCouponId = null,
+                totalPrice = 3000,
+                status = OrderStatus.COMPLETED
+            )
+        )
+        jpaOrderRepository.save(
+            OrderEntity(
+                id = 0,
+                userId = 1,
+                userCouponId = null,
+                totalPrice = 8000,
+                status = OrderStatus.COMPLETED
+            )
+        )
+        jpaOrderRepository.save(
+            OrderEntity(
+                id = 0,
+                userId = 1,
+                userCouponId = null,
+                totalPrice = 1000,
+                status = OrderStatus.PENDING
+            )
+        )
+        jpaOrderRepository.save(
+            OrderEntity(
+                id = 0,
+                userId = 1,
+                userCouponId = null,
+                totalPrice = 1000,
+                status = OrderStatus.COMPLETED
+            )
+        )
+
+        jpaOrderItemRepository.saveAll(
+            listOf(
+                OrderItemEntity(
+                    id = 0,
+                    orderId = 1,
+                    productId = 1,
+                    price = 1000,
+                    quantity = 1,
+                    createdAt = LocalDateTime.now()
+                ),
+                OrderItemEntity(
+                    id = 0,
+                    orderId = 1,
+                    productId = 2,
+                    price = 2000,
+                    quantity = 1,
+                    createdAt = LocalDateTime.now()
+                ),
+                OrderItemEntity(
+                    id = 0,
+                    orderId = 2,
+                    productId = 1,
+                    price = 1000,
+                    quantity = 8,
+                    createdAt = LocalDateTime.now()
+                ),
+                OrderItemEntity(
+                    id = 0,
+                    orderId = 3,
+                    productId = 1,
+                    price = 1000,
+                    quantity = 1,
+                    createdAt = LocalDateTime.now()
+                ),
+                OrderItemEntity(
+                    id = 0,
+                    orderId = 4,
+                    productId = 1,
+                    price = 1000,
+                    quantity = 1,
+                    createdAt = LocalDateTime.now().minusDays(4)
+                )
+            )
+        )
+
+        //  1. 최초 요청 → 캐시 미적중
+        val startMiss = System.currentTimeMillis()
+        restClient.get()
+            .uri("/api/v1/products/rank/cache")
+            .retrieve()
+            .body(object : ParameterizedTypeReference<ApiResponse<List<ProductRankingResponse>>>() {})
+        val endMiss = System.currentTimeMillis()
+        println("첫 요청 (캐시 미적중): ${endMiss - startMiss}ms")
+
+        //  2. 두 번째 요청 → 캐시 적중
+        val startHit = System.currentTimeMillis()
+        restClient.get()
+            .uri("/api/v1/products/rank/cache")
+            .retrieve()
+            .body(object : ParameterizedTypeReference<ApiResponse<List<ProductRankingResponse>>>() {})
+        val endHit = System.currentTimeMillis()
+        println("두 번째 요청 (캐시 적중): ${endHit - startHit}ms")
+
+        // then
+        assertThat((endMiss - startMiss)).isGreaterThan((endHit - startHit))
+    }
 }

--- a/src/test/java/kr/hhplus/be/server/support/E2ETestBase.kt
+++ b/src/test/java/kr/hhplus/be/server/support/E2ETestBase.kt
@@ -1,13 +1,20 @@
 package kr.hhplus.be.server.support
 
+
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.context.annotation.Import
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.MySQLContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
@@ -17,6 +24,7 @@ import org.testcontainers.utility.DockerImageName
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Testcontainers
 @ActiveProfiles("test")
+@Import(RedissonTestConfig::class)
 abstract class E2ETestBase {
 
     @LocalServerPort
@@ -24,6 +32,7 @@ abstract class E2ETestBase {
 
     @Autowired
     lateinit var jdbcTemplate: JdbcTemplate
+
 
     @BeforeEach
     fun cleanDatabase() {
@@ -40,7 +49,9 @@ abstract class E2ETestBase {
         }
 
         jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1")
+
     }
+
 
     companion object {
         @Container
@@ -50,12 +61,21 @@ abstract class E2ETestBase {
             withPassword("application")
         }
 
+        @Container
+        val redis = GenericContainer(DockerImageName.parse("redis:7.4.2")).apply{
+            withExposedPorts(6379)
+            start()
+        }
+
         @JvmStatic
         @DynamicPropertySource
         fun overrideProperties(registry: DynamicPropertyRegistry) {
             registry.add("spring.datasource.url", mysql::getJdbcUrl)
             registry.add("spring.datasource.username", mysql::getUsername)
             registry.add("spring.datasource.password", mysql::getPassword)
+
+            registry.add("spring.redis.host") {redis.host}
+            registry.add("spring.redis.port") {redis.getMappedPort(6379).toString()}
         }
     }
 }

--- a/src/test/java/kr/hhplus/be/server/support/RedissonTestConfig.kt
+++ b/src/test/java/kr/hhplus/be/server/support/RedissonTestConfig.kt
@@ -1,0 +1,28 @@
+package kr.hhplus.be.server.support
+
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+
+@TestConfiguration
+class RedissonTestConfig {
+    companion object {
+        val redis = GenericContainer(DockerImageName.parse("redis:7.4.2"))
+            .apply {
+                withExposedPorts(6379)
+                start() // 명시적 start
+            }
+    }
+    @Bean
+    fun redissonClient(): RedissonClient {
+        val config = Config().apply {
+            useSingleServer()
+                .setAddress("redis://${redis.host}:${redis.getMappedPort(6379)}")
+        }
+        return Redisson.create(config)
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,9 +1,8 @@
 spring:
-  spring:
-    datasource:
-      url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
-      username: application
-      password: application
+  datasource:
+    url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
+    username: application
+    password: application
   jpa:
     hibernate:
       ddl-auto: create-drop


### PR DESCRIPTION
### **커밋 링크**

레디스(인기상품) 캐시 설정 : 391d6b2f86c8ee1008f028fb5f02fd175d124d2d
캐싱 테스트 : 01265b3e8332c89eedfda28abaadff5f1c4970e4
적용 이후 성능분석 보고서 :  01265b3e8332c89eedfda28abaadff5f1c4970e4
레디스 캐시 설정 :  391d6b2f86c8ee1008f028fb5f02fd175d124d2d

---
### **리뷰 포인트(질문)**
- 현재는 스케줄러에서 인기 상품 캐시를 갱신하기 위해 ProductService의 동일한 로직을 호출하고 있습니다. 서비스 로직을 재사용하면서도 역할을 명확히 분리할 수 있는 설계가 있다면 조언 부탁드립니다.
- RedisConfig.kt(391d6b2f86c8ee1008f028fb5f02fd175d124d2d)에서 GenericJackson2JsonRedisSerializer를 설정하고 ObjectMapper에 JavaTimeModule, KotlinModule, DefaultTyping 등을 수동으로 구성했습니다. 현업에서는 Redis 직렬화/역직렬화 설정을 어떻게 관리하며, 보다 나은 설정 방식이 있다면 알려주시면 감사하겠습니다.

이번주는 멘토링 시간에 들은 내용을 바탕으로 전략을 선택해 봤는데, 덕분에 좋은 경험이 되었습니다. 감사합니다.

### **이번주 KPT 회고**

### Problem
<!--개선이 필요한 점-->
캐시 전략에 대해서 가볍게만 알고 있던 점
### Try
<!-- 새롭게 시도할 점 -->
DB 부하를 줄일 수 있도록 고민해본 점